### PR TITLE
Validation helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ local.properties
 *.stamp
 *.tlog
 *.vcxproj
+*.vcxproj.user
 *.zip
 /CMakeLists.txt
+CMakeCache.txt
 /MSVC
+/VKTS_Binaries
+.vs
+*.VC.db

--- a/VKTS/include/vkts/core/validation/ValidationHelpers.hpp
+++ b/VKTS/include/vkts/core/validation/ValidationHelpers.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#define REFLECT_TOKEN(Token) Token
+
+
+#define VALIDATE_CONDITION_WITH_DEFAULT(Condition, Message, Default) if (REFLECT_TOKEN(Condition)) { vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, #Message); return REFLECT_TOKEN(Default); }
+
+#define VALIDATE_CONDITION(Condition, Message) VALIDATE_CONDITION_WITH_DEFAULT(Condition, Message, VK_FALSE)
+
+
+#define VALIDATE_SUCCESS_WITH_DEFAULT(Result, Message, Default) if (Result != VK_SUCCESS) { vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, #Message); return REFLECT_TOKEN(Default); }
+
+#define VALIDATE_SUCCESS(Result, Message) VALIDATE_SUCCESS_WITH_DEFAULT(Result, Message, VK_FALSE)
+
+
+#define VALIDATE_INSTANCE_WITH_DEFAULT(Ptr, Message, Default) 	if (!REFLECT_TOKEN(Ptr).get()) { vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, #Message); return REFLECT_TOKEN(Default); }
+
+#define VALIDATE_INSTANCE(Ptr, Message) VALIDATE_INSTANCE_WITH_DEFAULT(Ptr, Message, VK_FALSE)

--- a/VKTS/include/vkts/core/vkts_core.hpp
+++ b/VKTS/include/vkts/core/vkts_core.hpp
@@ -65,6 +65,12 @@
 #include <glm/gtc/matrix_access.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
+ /**
+ * Validation Helpers.
+ */
+
+#include "validation/ValidationHelpers.hpp"
+
 /**
  * OS platform.
  */

--- a/VKTS/include/vkts/scenegraph/factory/ISceneFactory.hpp
+++ b/VKTS/include/vkts/scenegraph/factory/ISceneFactory.hpp
@@ -32,6 +32,8 @@
 namespace vkts
 {
 
+// TODO:	Shouldn't all of these methods return an IObjectSP since the other elements need an IObjectSP wrapper around them before they can be added to a scene?
+//			This could eliminate more boilerplate code.
 class ISceneFactory
 {
 

--- a/VKTS_Example04/src/Example.cpp
+++ b/VKTS_Example04/src/Example.cpp
@@ -1,33 +1,34 @@
 /**
- * VKTS Examples - Examples for Vulkan using VulKan ToolS.
- *
- * The MIT License (MIT)
- *
- * Copyright (c) since 2014 Norbert Nopper
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
+* VKTS Examples - Examples for Vulkan using VulKan ToolS.
+*
+* The MIT License (MIT)
+*
+* Copyright (c) since 2014 Norbert Nopper
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
 
 #include "Example.hpp"
 
 Example::Example(const vkts::IContextObjectSP& contextObject, const int32_t windowIndex, const vkts::IVisualContextSP& visualContext, const vkts::ISurfaceSP& surface) :
-		IUpdateThread(), contextObject(contextObject), windowIndex(windowIndex), visualContext(visualContext), surface(surface), commandPool(nullptr), imageAcquiredSemaphore(nullptr), renderingCompleteSemaphore(nullptr), descriptorSetLayout(nullptr), vertexViewProjectionUniformBuffer(nullptr), fragmentUniformBuffer(nullptr), vertexShaderModule(nullptr), fragmentShaderModule(nullptr), pipelineLayout(nullptr), renderFactory(nullptr), sceneManager(nullptr), sceneFactory(nullptr), scene(nullptr), swapchain(nullptr), renderPass(nullptr), allGraphicsPipelines(), depthTexture(nullptr), depthStencilImageView(nullptr), swapchainImagesCount(0), swapchainImageView(), framebuffer(), cmdBuffer(), cmdBufferFence()
+	IUpdateThread(), contextObject(contextObject), windowIndex(windowIndex), visualContext(visualContext), surface(surface), commandPool(nullptr), imageAcquiredSemaphore(nullptr), renderingCompleteSemaphore(nullptr), descriptorSetLayout(nullptr), vertexViewProjectionUniformBuffer(nullptr), fragmentUniformBuffer(nullptr), vertexShaderModule(nullptr), fragmentShaderModule(nullptr), pipelineLayout(nullptr), renderFactory(nullptr), sceneManager(nullptr), sceneFactory(nullptr), scene(nullptr), swapchain(nullptr), renderPass(nullptr), allGraphicsPipelines(), depthTexture(nullptr), depthStencilImageView(nullptr), swapchainImagesCount(0), swapchainImageView(), framebuffer(), cmdBuffer(), cmdBufferFence()
 {
 }
 
@@ -40,28 +41,16 @@ VkBool32 Example::buildCmdBuffer(const int32_t usedBuffer)
 	VkResult result;
 
 	cmdBuffer[usedBuffer] = vkts::commandBuffersCreate(contextObject->getDevice()->getDevice(), commandPool->getCmdPool(), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1);
-
-	if (!cmdBuffer[usedBuffer].get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create command buffer.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(cmdBuffer[usedBuffer], "Could not create command buffer.");
 
 	result = cmdBuffer[usedBuffer]->beginCommandBuffer(0, VK_NULL_HANDLE, 0, VK_NULL_HANDLE, VK_FALSE, 0, 0);
+	VALIDATE_SUCCESS(result, "Could not begin command buffer.");
 
-	if (result != VK_SUCCESS)
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not begin command buffer.");
+	//
 
-		return VK_FALSE;
-	}
+	swapchain->cmdPipelineBarrier(cmdBuffer[usedBuffer]->getCommandBuffer(), VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, usedBuffer);
 
-    //
-
-    swapchain->cmdPipelineBarrier(cmdBuffer[usedBuffer]->getCommandBuffer(), VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, usedBuffer);
-
-    //
+	//
 
 	VkClearColorValue clearColorValue{};
 
@@ -98,8 +87,8 @@ VkBool32 Example::buildCmdBuffer(const int32_t usedBuffer)
 
 	viewport.x = 0.0f;
 	viewport.y = 0.0f;
-	viewport.width = (float) swapchain->getImageExtent().width;
-	viewport.height = (float) swapchain->getImageExtent().height;
+	viewport.width = (float)swapchain->getImageExtent().width;
+	viewport.height = (float)swapchain->getImageExtent().height;
 	viewport.minDepth = 0.0f;
 	viewport.maxDepth = 1.0f;
 
@@ -120,20 +109,14 @@ VkBool32 Example::buildCmdBuffer(const int32_t usedBuffer)
 
 	cmdBuffer[usedBuffer]->cmdEndRenderPass();
 
-    //
+	//
 
-    swapchain->cmdPipelineBarrier(cmdBuffer[usedBuffer]->getCommandBuffer(), VK_ACCESS_MEMORY_READ_BIT, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, usedBuffer);
+	swapchain->cmdPipelineBarrier(cmdBuffer[usedBuffer]->getCommandBuffer(), VK_ACCESS_MEMORY_READ_BIT, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, usedBuffer);
 
-    //
+	//
 
 	result = cmdBuffer[usedBuffer]->endCommandBuffer();
-
-	if (result != VK_SUCCESS)
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not end command buffer.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_SUCCESS(result, "Could not end command buffer.");
 
 	return VK_TRUE;
 }
@@ -146,13 +129,7 @@ VkBool32 Example::buildFramebuffer(const int32_t usedBuffer)
 	imageViews[1] = depthStencilImageView->getImageView();
 
 	framebuffer[usedBuffer] = vkts::framebufferCreate(contextObject->getDevice()->getDevice(), 0, renderPass->getRenderPass(), 2, imageViews, swapchain->getImageExtent().width, swapchain->getImageExtent().height, 1);
-
-	if (!framebuffer[usedBuffer].get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create frame buffer.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(framebuffer[usedBuffer], "Could not create frame buffer.");
 
 	return VK_TRUE;
 }
@@ -163,13 +140,7 @@ VkBool32 Example::buildSwapchainImageView(const int32_t usedBuffer)
 	VkImageSubresourceRange imageSubresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
 
 	swapchainImageView[usedBuffer] = vkts::imageViewCreate(contextObject->getDevice()->getDevice(), 0, swapchain->getAllSwapchainImages()[usedBuffer], VK_IMAGE_VIEW_TYPE_2D, swapchain->getImageFormat(), componentMapping, imageSubresourceRange);
-
-	if (!swapchainImageView[usedBuffer].get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create color attachment view.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(swapchainImageView[usedBuffer], "Could not create color attachment view.");
 
 	return VK_TRUE;
 }
@@ -225,55 +196,31 @@ VkBool32 Example::updateDescriptorSets()
 VkBool32 Example::buildScene(const vkts::ICommandObjectSP& commandObject)
 {
 	renderFactory = vkts::sceneRenderFactoryCreate(descriptorSetLayout, vkts::IRenderPassSP(), vkts::IPipelineCacheSP(), VKTS_MAX_NUMBER_BUFFERS);
-
-	if (!renderFactory.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create data factory.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(renderFactory, "Could not create data factory.");
 
 	//
 
 	sceneFactory = vkts::sceneFactoryCreate(renderFactory);
-
-	if (!sceneFactory.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create factory.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(sceneFactory, "Could not create factory.");
 
 	//
 
 	sceneManager = vkts::sceneManagerCreate(VK_FALSE, contextObject, commandObject);
-
-	if (!sceneManager.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create cache.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(sceneManager, "Could not create cache.");
 
 	//
 
 	scene = vkts::sceneLoad(VKTS_SCENE_NAME, sceneManager, sceneFactory);
-
-	if (!scene.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not load scene.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(scene, "Could not load scene.");
 
 	vkts::logPrint(VKTS_LOG_INFO, __FILE__, __LINE__, "Number objects: %d", scene->getNumberObjects());
 
 	//
 
 	// Sorted by binding
-	dynamicOffsets[VKTS_BINDING_UNIFORM_BUFFER_VIEWPROJECTION] = VkTsDynamicOffset{0, (uint32_t)contextObject->getPhysicalDevice()->getUniformBufferAlignmentSizeInBytes(vkts::alignmentGetSizeInBytes(16 * sizeof(float) * 2, 16))};
-	dynamicOffsets[VKTS_BINDING_UNIFORM_BUFFER_TRANSFORM] = VkTsDynamicOffset{0, (uint32_t)sceneFactory->getSceneRenderFactory()->getTransformUniformBufferAlignmentSize(sceneManager)};
-	dynamicOffsets[VKTS_BINDING_UNIFORM_BUFFER_LIGHT] = VkTsDynamicOffset{0, (uint32_t)contextObject->getPhysicalDevice()->getUniformBufferAlignmentSizeInBytes(vkts::alignmentGetSizeInBytes(3 * sizeof(float), 16))};
+	dynamicOffsets[VKTS_BINDING_UNIFORM_BUFFER_VIEWPROJECTION] = VkTsDynamicOffset{ 0, (uint32_t)contextObject->getPhysicalDevice()->getUniformBufferAlignmentSizeInBytes(vkts::alignmentGetSizeInBytes(16 * sizeof(float) * 2, 16)) };
+	dynamicOffsets[VKTS_BINDING_UNIFORM_BUFFER_TRANSFORM] = VkTsDynamicOffset{ 0, (uint32_t)sceneFactory->getSceneRenderFactory()->getTransformUniformBufferAlignmentSize(sceneManager) };
+	dynamicOffsets[VKTS_BINDING_UNIFORM_BUFFER_LIGHT] = VkTsDynamicOffset{ 0, (uint32_t)contextObject->getPhysicalDevice()->getUniformBufferAlignmentSizeInBytes(vkts::alignmentGetSizeInBytes(3 * sizeof(float), 16)) };
 
 	//
 	// Free resources.
@@ -305,13 +252,7 @@ VkBool32 Example::buildDepthStencilImageView()
 	VkImageSubresourceRange imageSubresourceRange = { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 };
 
 	depthStencilImageView = vkts::imageViewCreate(contextObject->getDevice()->getDevice(), 0, depthTexture->getImage()->getImage(), VK_IMAGE_VIEW_TYPE_2D, depthTexture->getImage()->getFormat(), componentMapping, imageSubresourceRange);
-
-	if (!depthStencilImageView.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create depth attachment view.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(depthStencilImageView, "Could not create depth attachment view.");
 
 	return VK_TRUE;
 }
@@ -325,7 +266,7 @@ VkBool32 Example::buildDepthTexture(const vkts::ICommandBuffersSP& cmdBuffer)
 	imageCreateInfo.flags = 0;
 	imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
 	imageCreateInfo.format = VK_FORMAT_D16_UNORM;
-	imageCreateInfo.extent = {swapchain->getImageExtent().width, swapchain->getImageExtent().height, 1};
+	imageCreateInfo.extent = { swapchain->getImageExtent().width, swapchain->getImageExtent().height, 1 };
 	imageCreateInfo.mipLevels = 1;
 	imageCreateInfo.arrayLayers = 1;
 	imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -339,13 +280,7 @@ VkBool32 Example::buildDepthTexture(const vkts::ICommandBuffersSP& cmdBuffer)
 	VkImageSubresourceRange subresourceRange = { VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1 };
 
 	depthTexture = vkts::imageObjectCreate(contextObject, cmdBuffer, "DepthTexture", imageCreateInfo, 0, VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, subresourceRange, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-	if (!depthTexture.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create depth texture.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(depthTexture, "Could not create depth texture.");
 
 	return VK_TRUE;
 }
@@ -423,8 +358,8 @@ VkBool32 Example::buildPipeline()
 
 	viewport.x = 0.0f;
 	viewport.y = 0.0f;
-	viewport.width = (float) swapchain->getImageExtent().width;
-	viewport.height = (float) swapchain->getImageExtent().height;
+	viewport.width = (float)swapchain->getImageExtent().width;
+	viewport.height = (float)swapchain->getImageExtent().height;
 	viewport.minDepth = 0.0f;
 	viewport.maxDepth = 1.0f;
 
@@ -568,13 +503,7 @@ VkBool32 Example::buildPipeline()
 	graphicsPipelineCreateInfo.basePipelineIndex = 0;
 
 	auto pipeline = vkts::pipelineCreateGraphics(contextObject->getDevice()->getDevice(), VK_NULL_HANDLE, graphicsPipelineCreateInfo, vertexBufferType);
-
-	if (!pipeline.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create graphics pipeline.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(pipeline, "Could not create graphics pipeline.");
 
 	allGraphicsPipelines.append(pipeline);
 
@@ -628,14 +557,8 @@ VkBool32 Example::buildRenderPass()
 	subpassDescription.preserveAttachmentCount = 0;
 	subpassDescription.pPreserveAttachments = nullptr;
 
-	renderPass = vkts::renderPassCreate( contextObject->getDevice()->getDevice(), 0, 2, attachmentDescription, 1, &subpassDescription, 0, nullptr);
-
-	if (!renderPass.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create render pass.");
-
-		return VK_FALSE;
-	}
+	renderPass = vkts::renderPassCreate(contextObject->getDevice()->getDevice(), 0, 2, attachmentDescription, 1, &subpassDescription, 0, nullptr);
+	VALIDATE_INSTANCE(renderPass, "Could not create render pass.");
 
 	return VK_TRUE;
 }
@@ -647,13 +570,7 @@ VkBool32 Example::buildPipelineLayout()
 	setLayouts[0] = descriptorSetLayout->getDescriptorSetLayout();
 
 	pipelineLayout = vkts::pipelineCreateLayout(contextObject->getDevice()->getDevice(), 0, 1, setLayouts, 0, nullptr);
-
-	if (!pipelineLayout.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create pipeline layout.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(pipelineLayout, "Could not create pipeline layout.");
 
 	return VK_TRUE;
 }
@@ -680,25 +597,19 @@ VkBool32 Example::buildDescriptorSetLayout()
 	descriptorSetLayoutBinding[2].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
 	descriptorSetLayoutBinding[2].pImmutableSamplers = nullptr;
 
-    for (int32_t i = VKTS_BINDING_UNIFORM_SAMPLER_PHONG_FIRST; i <= VKTS_BINDING_UNIFORM_SAMPLER_PHONG_LAST; i++)
-    {
+	for (int32_t i = VKTS_BINDING_UNIFORM_SAMPLER_PHONG_FIRST; i <= VKTS_BINDING_UNIFORM_SAMPLER_PHONG_LAST; i++)
+	{
 		descriptorSetLayoutBinding[3 + i - VKTS_BINDING_UNIFORM_SAMPLER_PHONG_FIRST].binding = i;
 		descriptorSetLayoutBinding[3 + i - VKTS_BINDING_UNIFORM_SAMPLER_PHONG_FIRST].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 		descriptorSetLayoutBinding[3 + i - VKTS_BINDING_UNIFORM_SAMPLER_PHONG_FIRST].descriptorCount = 1;
 		descriptorSetLayoutBinding[3 + i - VKTS_BINDING_UNIFORM_SAMPLER_PHONG_FIRST].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 		descriptorSetLayoutBinding[3 + i - VKTS_BINDING_UNIFORM_SAMPLER_PHONG_FIRST].pImmutableSamplers = nullptr;
-    }
-
-    //
-
-    descriptorSetLayout = vkts::descriptorSetLayoutCreate(contextObject->getDevice()->getDevice(), 0, VKTS_DESCRIPTOR_SET_COUNT, descriptorSetLayoutBinding);
-
-	if (!descriptorSetLayout.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create descriptor set layout.");
-
-		return VK_FALSE;
 	}
+
+	//
+
+	descriptorSetLayout = vkts::descriptorSetLayoutCreate(contextObject->getDevice()->getDevice(), 0, VKTS_DESCRIPTOR_SET_COUNT, descriptorSetLayoutBinding);
+	VALIDATE_INSTANCE(descriptorSetLayout, "Could not create descriptor set layout.");
 
 	return VK_TRUE;
 }
@@ -706,42 +617,18 @@ VkBool32 Example::buildDescriptorSetLayout()
 VkBool32 Example::buildShader()
 {
 	auto vertexShaderBinary = vkts::fileLoadBinary(VKTS_VERTEX_SHADER_NAME);
-
-	if (!vertexShaderBinary.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not load vertex shader: '%s'", VKTS_VERTEX_SHADER_NAME);
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(vertexShaderBinary, "Could not load vertex shader: '" + VKTS_VERTEX_SHADER_NAME + "'");
 
 	auto fragmentShaderBinary = vkts::fileLoadBinary(VKTS_FRAGMENT_SHADER_NAME);
-
-	if (!fragmentShaderBinary.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not load fragment shader: '%s'", VKTS_FRAGMENT_SHADER_NAME);
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(fragmentShaderBinary, "Could not load fragment shader: '" + VKTS_FRAGMENT_SHADER_NAME + "'");
 
 	//
 
 	vertexShaderModule = vkts::shaderModuleCreate(VKTS_VERTEX_SHADER_NAME, contextObject->getDevice()->getDevice(), 0, vertexShaderBinary->getSize(), (uint32_t*)vertexShaderBinary->getData());
-
-	if (!vertexShaderModule.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create vertex shader module.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(vertexShaderModule, "Could not create vertex shader module.");
 
 	fragmentShaderModule = vkts::shaderModuleCreate(VKTS_FRAGMENT_SHADER_NAME, contextObject->getDevice()->getDevice(), 0, fragmentShaderBinary->getSize(), (uint32_t*)fragmentShaderBinary->getData());
-
-	if (!fragmentShaderModule.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create fragment shader module.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(fragmentShaderModule, "Could not create fragment shader module.");
 
 	return VK_TRUE;
 }
@@ -760,33 +647,13 @@ VkBool32 Example::buildUniformBuffers()
 	bufferCreateInfo.pQueueFamilyIndices = nullptr;
 
 	vertexViewProjectionUniformBuffer = vkts::bufferObjectCreate(contextObject, bufferCreateInfo, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VKTS_MAX_NUMBER_BUFFERS);
+	VALIDATE_INSTANCE(vertexViewProjectionUniformBuffer, "Could not create vertex uniform buffer.");
 
-	if (!vertexViewProjectionUniformBuffer.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create vertex uniform buffer.");
-
-		return VK_FALSE;
-	}
-
-	memset(&bufferCreateInfo, 0, sizeof(VkBufferCreateInfo));
-
-	bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-
-	bufferCreateInfo.flags = 0;
+	// Only change the size of it and then reuse the bufferCreateInfo.
 	bufferCreateInfo.size = vkts::alignmentGetSizeInBytes(3 * sizeof(float), 16);
-	bufferCreateInfo.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-	bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-	bufferCreateInfo.queueFamilyIndexCount = 0;
-	bufferCreateInfo.pQueueFamilyIndices = nullptr;
 
 	fragmentUniformBuffer = vkts::bufferObjectCreate(contextObject, bufferCreateInfo, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, VKTS_MAX_NUMBER_BUFFERS);
-
-	if (!fragmentUniformBuffer.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create fragment uniform buffer.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(fragmentUniformBuffer, "Could not create fragment uniform buffer.");
 
 	return VK_TRUE;
 }
@@ -802,48 +669,30 @@ VkBool32 Example::buildResources(const vkts::IUpdateThreadContext& updateContext
 	VkSwapchainKHR oldSwapchain = lastSwapchain.get() ? lastSwapchain->getSwapchain() : VK_NULL_HANDLE;
 
 	swapchain = vkts::wsiSwapchainCreate(contextObject->getPhysicalDevice()->getPhysicalDevice(), contextObject->getDevice()->getDevice(), 0, surface->getSurface(), VKTS_NUMBER_BUFFERS, 1, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SHARING_MODE_EXCLUSIVE, 0, nullptr, VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR, VK_PRESENT_MODE_FIFO_KHR, VK_TRUE, oldSwapchain);
+	VALIDATE_INSTANCE(swapchain, "Could not create swap chain.");
 
-	if (!swapchain.get())
+	//
+
+	swapchainImagesCount = (uint32_t)swapchain->getAllSwapchainImages().size();
+	VALIDATE_CONDITION(swapchainImagesCount == 0, "Could not get swap chain images count.");
+
+	if (swapchainImagesCount > VKTS_MAX_NUMBER_BUFFERS)
 	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create swap chain.");
-
 		return VK_FALSE;
 	}
 
-    //
+	swapchainImageView = vkts::SmartPointerVector<vkts::IImageViewSP>(swapchainImagesCount);
+	framebuffer = vkts::SmartPointerVector<vkts::IFramebufferSP>(swapchainImagesCount);
+	cmdBuffer = vkts::SmartPointerVector<vkts::ICommandBuffersSP>(swapchainImagesCount);
+	cmdBufferFence = vkts::SmartPointerVector<vkts::IFenceSP>(swapchainImagesCount);
 
-    swapchainImagesCount = (uint32_t)swapchain->getAllSwapchainImages().size();
+	for (uint32_t i = 0; i < swapchainImagesCount; i++)
+	{
+		cmdBufferFence[i] = vkts::fenceCreate(contextObject->getDevice()->getDevice(), VK_FENCE_CREATE_SIGNALED_BIT);
+		VALIDATE_INSTANCE(cmdBufferFence[i], "Could not create fence.");
+	}
 
-    if (swapchainImagesCount == 0)
-    {
-        vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not get swap chain images count.");
-
-        return VK_FALSE;
-    }
-
-    if (swapchainImagesCount > VKTS_MAX_NUMBER_BUFFERS)
-    {
-    	return VK_FALSE;
-    }
-
-    swapchainImageView = vkts::SmartPointerVector<vkts::IImageViewSP>(swapchainImagesCount);
-    framebuffer = vkts::SmartPointerVector<vkts::IFramebufferSP>(swapchainImagesCount);
-    cmdBuffer = vkts::SmartPointerVector<vkts::ICommandBuffersSP>(swapchainImagesCount);
-    cmdBufferFence = vkts::SmartPointerVector<vkts::IFenceSP>(swapchainImagesCount);
-
-    for (uint32_t i = 0; i < swapchainImagesCount; i++)
-    {
-    	cmdBufferFence[i] = vkts::fenceCreate(contextObject->getDevice()->getDevice(), VK_FENCE_CREATE_SIGNALED_BIT);
-
-        if (!cmdBufferFence[i].get())
-        {
-            vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create fence.");
-
-            return VK_FALSE;
-        }
-    }
-
-    //
+	//
 
 	if (lastSwapchain.get())
 	{
@@ -865,35 +714,17 @@ VkBool32 Example::buildResources(const vkts::IUpdateThreadContext& updateContext
 	//
 
 	vkts::ICommandBuffersSP updateCmdBuffer = vkts::commandBuffersCreate(contextObject->getDevice()->getDevice(), commandPool->getCmdPool(), VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1);
-
-	if (!updateCmdBuffer.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create command buffer.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(updateCmdBuffer, "Could not create command buffer.");
 
 	//
 
 	auto commandObject = vkts::commandObjectCreate(updateCmdBuffer);
-
-	if (!commandObject.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create command object.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(commandObject, "Could not create command object.");
 
 	//
 
 	result = updateCmdBuffer->beginCommandBuffer(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, VK_NULL_HANDLE, 0, VK_NULL_HANDLE, VK_FALSE, 0, 0);
-
-	if (result != VK_SUCCESS)
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not begin command buffer.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_SUCCESS(result, "Could not begin command buffer.");
 
 	if (!buildDepthTexture(updateCmdBuffer))
 	{
@@ -917,13 +748,7 @@ VkBool32 Example::buildResources(const vkts::IUpdateThreadContext& updateContext
 	}
 
 	result = updateCmdBuffer->endCommandBuffer();
-
-	if (result != VK_SUCCESS)
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not end command buffer.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_SUCCESS(result, "Could not end command buffer.");
 
 
 	VkSubmitInfo submitInfo{};
@@ -938,22 +763,10 @@ VkBool32 Example::buildResources(const vkts::IUpdateThreadContext& updateContext
 	submitInfo.pSignalSemaphores = nullptr;
 
 	result = contextObject->getQueue()->submit(1, &submitInfo, VK_NULL_HANDLE);
-
-	if (result != VK_SUCCESS)
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not submit queue.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_SUCCESS(result, "Could not submit queue.");
 
 	result = contextObject->getQueue()->waitIdle();
-
-	if (result != VK_SUCCESS)
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not wait for idle queue.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_SUCCESS(result, "Could not wait for idle queue.");
 
 	commandObject->destroy();
 
@@ -1015,10 +828,10 @@ void Example::terminateResources(const vkts::IUpdateThreadContext& updateContext
 
 			for (int32_t i = 0; i < (int32_t)swapchainImagesCount; i++)
 			{
-		        if (cmdBufferFence[i].get())
-		        {
-		        	cmdBufferFence[i]->destroy();
-		        }
+				if (cmdBufferFence[i].get())
+				{
+					cmdBufferFence[i]->destroy();
+				}
 
 				if (cmdBuffer[i].get())
 				{
@@ -1071,7 +884,6 @@ VkBool32 Example::init(const vkts::IUpdateThreadContext& updateContext)
 
 		return VK_FALSE;
 	}
-
 	//
 
 	surface->hasCurrentExtentChanged(contextObject->getPhysicalDevice()->getPhysicalDevice());
@@ -1079,33 +891,15 @@ VkBool32 Example::init(const vkts::IUpdateThreadContext& updateContext)
 	//
 
 	commandPool = vkts::commandPoolCreate(contextObject->getDevice()->getDevice(), 0, contextObject->getQueue()->getQueueFamilyIndex());
-
-	if (!commandPool.get())
-	{
-		vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not get command pool.");
-
-		return VK_FALSE;
-	}
+	VALIDATE_INSTANCE(commandPool, "Could not get command pool.");
 
 	//
 
-    imageAcquiredSemaphore = vkts::semaphoreCreate(contextObject->getDevice()->getDevice(), 0);
+	imageAcquiredSemaphore = vkts::semaphoreCreate(contextObject->getDevice()->getDevice(), 0);
+	VALIDATE_INSTANCE(imageAcquiredSemaphore, "Could not create semaphore.");
 
-    if (!imageAcquiredSemaphore.get())
-    {
-        vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create semaphore.");
-
-        return VK_FALSE;
-    }
-
-    renderingCompleteSemaphore = vkts::semaphoreCreate(contextObject->getDevice()->getDevice(), 0);
-
-    if (!renderingCompleteSemaphore.get())
-    {
-        vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not create semaphore.");
-
-        return VK_FALSE;
-    }
+	renderingCompleteSemaphore = vkts::semaphoreCreate(contextObject->getDevice()->getDevice(), 0);
+	VALIDATE_INSTANCE(renderingCompleteSemaphore, "Could not create semaphore.");
 
 	//
 
@@ -1184,20 +978,10 @@ VkBool32 Example::update(const vkts::IUpdateThreadContext& updateContext)
 	{
 		// Wait until complete, before to commit again.
 		result = cmdBufferFence[currentBuffer]->waitForFence(UINT64_MAX);
-		if (result != VK_SUCCESS)
-		{
-			vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not wait for fence.");
-
-			return VK_FALSE;
-		}
+		VALIDATE_SUCCESS(result, "Could not wait for fence.");
 
 		result = cmdBufferFence[currentBuffer]->reset();
-		if (result != VK_SUCCESS)
-		{
-			vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not reset fence.");
-
-			return VK_FALSE;
-		}
+		VALIDATE_SUCCESS(result, "Could not reset fence.");
 
 		//
 
@@ -1242,38 +1026,32 @@ VkBool32 Example::update(const vkts::IUpdateThreadContext& updateContext)
 
 		//
 
-        VkSemaphore waitSemaphores = imageAcquiredSemaphore->getSemaphore();
-        VkSemaphore signalSemaphores = renderingCompleteSemaphore->getSemaphore();
+		VkSemaphore waitSemaphores = imageAcquiredSemaphore->getSemaphore();
+		VkSemaphore signalSemaphores = renderingCompleteSemaphore->getSemaphore();
 
 
-        VkPipelineStageFlags waitDstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		VkPipelineStageFlags waitDstStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
 
-        VkSubmitInfo submitInfo{};
+		VkSubmitInfo submitInfo{};
 
-        submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
-        submitInfo.waitSemaphoreCount = 1;
-        submitInfo.pWaitSemaphores = &waitSemaphores;
-        submitInfo.pWaitDstStageMask = &waitDstStageMask;
-        submitInfo.commandBufferCount = 1;
-        submitInfo.pCommandBuffers = cmdBuffer[currentBuffer]->getCommandBuffers();
-        submitInfo.signalSemaphoreCount = 1;
-        submitInfo.pSignalSemaphores = &signalSemaphores;
+		submitInfo.waitSemaphoreCount = 1;
+		submitInfo.pWaitSemaphores = &waitSemaphores;
+		submitInfo.pWaitDstStageMask = &waitDstStageMask;
+		submitInfo.commandBufferCount = 1;
+		submitInfo.pCommandBuffers = cmdBuffer[currentBuffer]->getCommandBuffers();
+		submitInfo.signalSemaphoreCount = 1;
+		submitInfo.pSignalSemaphores = &signalSemaphores;
 
 		result = contextObject->getQueue()->submit(1, &submitInfo, cmdBufferFence[currentBuffer]->getFence());
+		VALIDATE_SUCCESS(result, "Could not submit queue.");
 
-		if (result != VK_SUCCESS)
-		{
-			vkts::logPrint(VKTS_LOG_ERROR, __FILE__, __LINE__, "Could not submit queue.");
+		waitSemaphores = renderingCompleteSemaphore->getSemaphore();
 
-			return VK_FALSE;
-		}
+		VkSwapchainKHR swapchains = swapchain->getSwapchain();
 
-        waitSemaphores = renderingCompleteSemaphore->getSemaphore();
-
-        VkSwapchainKHR swapchains = swapchain->getSwapchain();
-
-        result = swapchain->queuePresent(contextObject->getQueue()->getQueue(), 1, &waitSemaphores, 1, &swapchains, &currentBuffer, nullptr);
+		result = swapchain->queuePresent(contextObject->getQueue()->getQueue(), 1, &waitSemaphores, 1, &swapchains, &currentBuffer, nullptr);
 
 		if (result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR)
 		{
@@ -1394,15 +1172,15 @@ void Example::terminate(const vkts::IUpdateThreadContext& updateContext)
 				descriptorSetLayout->destroy();
 			}
 
-	        if (renderingCompleteSemaphore.get())
-	        {
-	        	renderingCompleteSemaphore->destroy();
-	        }
+			if (renderingCompleteSemaphore.get())
+			{
+				renderingCompleteSemaphore->destroy();
+			}
 
-	        if (imageAcquiredSemaphore.get())
-	        {
-	            imageAcquiredSemaphore->destroy();
-	        }
+			if (imageAcquiredSemaphore.get())
+			{
+				imageAcquiredSemaphore->destroy();
+			}
 
 			if (commandPool.get())
 			{

--- a/VKTS_PKG_Interactive/src/interactive/input_controller/InputController.cpp
+++ b/VKTS_PKG_Interactive/src/interactive/input_controller/InputController.cpp
@@ -26,6 +26,8 @@
 
 #include "InputController.hpp"
 
+// TODO:	Input control mapping should be handled via a configuraion file not programmatically.
+
 namespace vkts
 {
 
@@ -264,89 +266,87 @@ VkBool32 InputController::update(const double deltaTime, const uint64_t deltaTic
 
                 moveable->moveTranslateRotate(forwardFactor, strafeFactor, upFactor, deltaRotation);
             }
-            else if (gamepadIndex < 0)
+
+            // Keyboard
+
+            float moveSpeedFactor = 1.0f;
+            float rotateSpeedFactor = 1.0f;
+            if (visualContext->getKey(windowIndex, VKTS_KEY_LEFT_SHIFT))
             {
-                // Keyboard
+                moveSpeedFactor = moveMulitply;
+                rotateSpeedFactor = rotateMulitply;
+            }
 
-                float moveSpeedFactor = 1.0f;
-                float rotateSpeedFactor = 1.0f;
-                if (visualContext->getKey(windowIndex, VKTS_KEY_LEFT_SHIFT))
-                {
-                    moveSpeedFactor = moveMulitply;
-                    rotateSpeedFactor = rotateMulitply;
-                }
+            float forwardFactor = 0.0f;
+            if (visualContext->getKey(windowIndex, VKTS_KEY_W))
+            {
+                forwardFactor += 1.0f * forwardSpeed * moveSpeedFactor * (float) deltaTime;
+            }
+            if (visualContext->getKey(windowIndex, VKTS_KEY_S))
+            {
+                forwardFactor -= 1.0f * forwardSpeed * moveSpeedFactor * (float) deltaTime;
+            }
 
-                float forwardFactor = 0.0f;
-                if (visualContext->getKey(windowIndex, VKTS_KEY_W))
-                {
-                    forwardFactor += 1.0f * forwardSpeed * moveSpeedFactor * (float) deltaTime;
-                }
-                if (visualContext->getKey(windowIndex, VKTS_KEY_S))
-                {
-                    forwardFactor -= 1.0f * forwardSpeed * moveSpeedFactor * (float) deltaTime;
-                }
+            float strafeFactor = 0.0f;
+            if (visualContext->getKey(windowIndex, VKTS_KEY_D))
+            {
+                strafeFactor -= 1.0f * strafeSpeed * moveSpeedFactor * (float) deltaTime;
+            }
+            if (visualContext->getKey(windowIndex, VKTS_KEY_A))
+            {
+                strafeFactor += 1.0f * strafeSpeed * moveSpeedFactor * (float) deltaTime;
+            }
 
-                float strafeFactor = 0.0f;
-                if (visualContext->getKey(windowIndex, VKTS_KEY_D))
-                {
-                    strafeFactor -= 1.0f * strafeSpeed * moveSpeedFactor * (float) deltaTime;
-                }
-                if (visualContext->getKey(windowIndex, VKTS_KEY_A))
-                {
-                    strafeFactor += 1.0f * strafeSpeed * moveSpeedFactor * (float) deltaTime;
-                }
+            float upFactor = 0.0f;
+            if (visualContext->getKey(windowIndex, VKTS_KEY_E) || visualContext->getKey(windowIndex, VKTS_KEY_PAGE_UP))
+            {
+                upFactor += 1.0f * upSpeed * moveSpeedFactor * (float) deltaTime;
+            }
+            if (visualContext->getKey(windowIndex, VKTS_KEY_Q) || visualContext->getKey(windowIndex, VKTS_KEY_PAGE_DOWN))
+            {
+                upFactor -= 1.0f * upSpeed * moveSpeedFactor * (float) deltaTime;
+            }
 
-                float upFactor = 0.0f;
-                if (visualContext->getKey(windowIndex, VKTS_KEY_PAGE_UP))
-                {
-                    upFactor += 1.0f * upSpeed * moveSpeedFactor * (float) deltaTime;
-                }
-                if (visualContext->getKey(windowIndex, VKTS_KEY_PAGE_DOWN))
-                {
-                    upFactor -= 1.0f * upSpeed * moveSpeedFactor * (float) deltaTime;
-                }
+            if (forwardOnly && forwardFactor > 0.0f)
+            {
+                forwardFactor = 0.0f;
+            }
 
-                if (forwardOnly && forwardFactor > 0.0f)
+            glm::vec3 deltaRotation(0.0f, 0.0f, 0.0f);
+
+            const auto& currentMouseLocation = visualContext->getMouseLocation(windowIndex);
+
+            if (visualContext->isGameMouse(windowIndex))
+            {
+                if (!mouseLocationInitialized)
                 {
-                	forwardFactor = 0.0f;
-                }
-
-                glm::vec3 deltaRotation(0.0f, 0.0f, 0.0f);
-
-                const auto& currentMouseLocation = visualContext->getMouseLocation(windowIndex);
-
-                if (visualContext->isGameMouse(windowIndex))
-                {
-                    if (!mouseLocationInitialized)
+                    if (currentMouseLocation.y == (int32_t)visualContext->getWindowDimension(windowIndex).y / 2 && currentMouseLocation.x == (int32_t)visualContext->getWindowDimension(windowIndex).x / 2)
                     {
-                        if (currentMouseLocation.y == (int32_t)visualContext->getWindowDimension(windowIndex).y / 2 && currentMouseLocation.x == (int32_t)visualContext->getWindowDimension(windowIndex).x / 2)
-                        {
-                            mouseLocationInitialized = VK_TRUE;
-                        }
-                    }
-                    else
-                    {
-                        deltaRotation.x = -(float)(2 * (currentMouseLocation.y - (int32_t)visualContext->getWindowDimension(windowIndex).y / 2)) / (float) visualContext->getWindowDimension(windowIndex).y * pitchSpeed * rotateSpeedFactor * pitchMulitply * (float) deltaTime * mouseMultiply;
-                        deltaRotation.y = -(float)(2 * (currentMouseLocation.x - (int32_t)visualContext->getWindowDimension(windowIndex).x / 2)) / (float) visualContext->getWindowDimension(windowIndex).x * yawSpeed * rotateSpeedFactor * (float) deltaTime * mouseMultiply;
+                        mouseLocationInitialized = VK_TRUE;
                     }
                 }
                 else
                 {
-                    if (!mouseLocationInitialized)
-                    {
-                        lastMouseLocation = currentMouseLocation;
+                    deltaRotation.x = -(float)(2 * (currentMouseLocation.y - (int32_t)visualContext->getWindowDimension(windowIndex).y / 2)) / (float) visualContext->getWindowDimension(windowIndex).y * pitchSpeed * rotateSpeedFactor * pitchMulitply * (float) deltaTime * mouseMultiply;
+                    deltaRotation.y = -(float)(2 * (currentMouseLocation.x - (int32_t)visualContext->getWindowDimension(windowIndex).x / 2)) / (float) visualContext->getWindowDimension(windowIndex).x * yawSpeed * rotateSpeedFactor * (float) deltaTime * mouseMultiply;
+                }
+            }
+            else
+            {
+                if (!mouseLocationInitialized)
+                {
+                    lastMouseLocation = currentMouseLocation;
 
-                        mouseLocationInitialized = VK_TRUE;
-                    }
-
-                    deltaRotation.x = -(float)(2 * (currentMouseLocation.y - lastMouseLocation.y)) / (float) visualContext->getWindowDimension(windowIndex).y * pitchSpeed * rotateSpeedFactor * pitchMulitply * (float) deltaTime * mouseMultiply;
-                    deltaRotation.y = -(float)(2 * (currentMouseLocation.x - lastMouseLocation.x)) / (float) visualContext->getWindowDimension(windowIndex).x * yawSpeed * rotateSpeedFactor * (float) deltaTime * mouseMultiply;
-
-                    lastMouseLocation = glm::ivec2(currentMouseLocation.x, currentMouseLocation.y);
+                    mouseLocationInitialized = VK_TRUE;
                 }
 
-                moveable->moveTranslateRotate(forwardFactor, strafeFactor, upFactor, deltaRotation);
+                deltaRotation.x = -(float)(2 * (currentMouseLocation.y - lastMouseLocation.y)) / (float) visualContext->getWindowDimension(windowIndex).y * pitchSpeed * rotateSpeedFactor * pitchMulitply * (float) deltaTime * mouseMultiply;
+                deltaRotation.y = -(float)(2 * (currentMouseLocation.x - lastMouseLocation.x)) / (float) visualContext->getWindowDimension(windowIndex).x * yawSpeed * rotateSpeedFactor * (float) deltaTime * mouseMultiply;
+
+                lastMouseLocation = glm::ivec2(currentMouseLocation.x, currentMouseLocation.y);
             }
+
+            moveable->moveTranslateRotate(forwardFactor, strafeFactor, upFactor, deltaRotation);
         }
     }
 

--- a/VKTS_PKG_Scenegraph/src/scenegraph/scene/Node.cpp
+++ b/VKTS_PKG_Scenegraph/src/scenegraph/scene/Node.cpp
@@ -1006,7 +1006,7 @@ void Node::updateTransformRecursive(const double deltaTime, const uint64_t delta
 
         Quat a;
         Quat b;
-        float t;
+        float t = 0;
         VkBool32 quaternionDirty = VK_FALSE;
 
         //

--- a/VKTS_PKG_VulkanWrapper/src/wrapper/extension/fn_validation.cpp
+++ b/VKTS_PKG_VulkanWrapper/src/wrapper/extension/fn_validation.cpp
@@ -55,16 +55,17 @@ VkBool32 VKTS_APIENTRY validationGatherNeededInstanceLayers()
 
     //
 
-    static const char* validationLayerNames[7] =
+    static const char* validationLayerNames[8] =
     {
-        "VK_LAYER_GOOGLE_threading",
-        "VK_LAYER_LUNARG_parameter_validation",
-        "VK_LAYER_LUNARG_object_tracker",
+		"VK_LAYER_GOOGLE_threading",
+		"VK_LAYER_LUNARG_parameter_validation",
+		"VK_LAYER_LUNARG_device_limits",
+		"VK_LAYER_LUNARG_object_tracker",
 		"VK_LAYER_LUNARG_image",
-        "VK_LAYER_LUNARG_core_validation",
-        "VK_LAYER_LUNARG_swapchain",
-        "VK_LAYER_GOOGLE_unique_objects"
-    };
+		"VK_LAYER_LUNARG_core_validation",
+		"VK_LAYER_LUNARG_swapchain",
+		"VK_LAYER_GOOGLE_unique_objects"
+	};
 
     for (auto validationLayerName : validationLayerNames)
     {
@@ -76,8 +77,10 @@ VkBool32 VKTS_APIENTRY validationGatherNeededInstanceLayers()
 			{
 				if (!layerAddInstanceLayers(validationLayerName))
 				{
-					return VK_FALSE;
+					vkts::logPrint(VKTS_LOG_WARNING, __FILE__, __LINE__, "Could not add validation layer: %s", validationLayerName);
 				}
+
+				vkts::logPrint(VKTS_LOG_INFO, __FILE__, __LINE__, "Successfully added validation layer: %s", validationLayerName);
 
 				extensionFound = VK_TRUE;
 
@@ -87,7 +90,7 @@ VkBool32 VKTS_APIENTRY validationGatherNeededInstanceLayers()
 
 		if (!extensionFound)
 		{
-			return VK_FALSE;
+			vkts::logPrint(VKTS_LOG_WARNING, __FILE__, __LINE__, "Could not find validation layer: %s", validationLayerName);
 		}
     }
 


### PR DESCRIPTION
Introduced helper macros for validating object instances, operation results and conditions to reduce the amount of boilerplate code. Updated the Example04 project to use the helper macros which reduced the number of lines of code from 1413 to 1191. Less code is easier to read and follow, and this reduces the barrier for entry for developers to adopt the framework.