### PR TITLE
Align _visualGetNumberDisplays() implementation with other code

### DIFF
--- a/VKTS_PKG_Window/src/window/visual/fn_visual_win32.cpp
+++ b/VKTS_PKG_Window/src/window/visual/fn_visual_win32.cpp
@@ -448,7 +448,17 @@ VkBool32 VKTS_APIENTRY _visualDispatchMessages()
 
 int32_t VKTS_APIENTRY _visualGetNumberDisplays()
 {
-    return static_cast<int32_t>(GetSystemMetrics(SM_CMONITORS));
+    int32_t displayCount = 0;
+
+    DISPLAY_DEVICE dd;
+    dd.cb = sizeof(DISPLAY_DEVICE);
+
+    while (EnumDisplayDevices(NULL, displayCount, &dd, 0))
+    {
+        displayCount += 1;
+    }
+
+    return displayCount;
 }
 
 INativeDisplayWP VKTS_APIENTRY _visualCreateDefaultDisplay()


### PR DESCRIPTION
The implementation of _visualGetNumberDisplays() with
GetSystemMetrics(SM_CMONITORS) would sometimes mismatch the other parts
of the code that would use EnumDisplayDevices().

Changing _visualGetNumberDisplays() to count the displays with
EnumDisplayDevices() instead fixes the issue.